### PR TITLE
OGCA-208 Add Prowler required permissions for security audit

### DIFF
--- a/CloudFormation/CrossAccountRoleWithManagedPolicy.yaml
+++ b/CloudFormation/CrossAccountRoleWithManagedPolicy.yaml
@@ -23,6 +23,7 @@ Parameters:
       - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
       - arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess
       - arn:aws:iam::aws:policy/ReadOnlyAccess
+      - Security-Audit-with-Prowler
     Description: >
       AWS managed policy to attach to the role (Default: ReadOnlyAccess).
 
@@ -34,12 +35,12 @@ Metadata:
       - Label: 
           default: "Role Name and Permissions"
         Parameters: 
-          - RoleName
           - ManagedPolicyArn
       - Label: 
           default: "OpsGuru Provided Parameter Values"
         Parameters: 
           - Principal
+          - RoleName
 
 
 Resources:
@@ -58,8 +59,18 @@ Resources:
               Ref: Principal
           Action: sts:AssumeRole
       ManagedPolicyArns:
-      - Ref: ManagedPolicyArn
+        # If "Security-Audit-with-Prowler" is selected, attach both SecurityAudit and ViewOnlyAccess policies
+        Fn::If:
+          - UseProwlerPolicies
+          - 
+            - arn:aws:iam::aws:policy/SecurityAudit
+            - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+          - 
+            - Ref: ManagedPolicyArn
 
+Conditions:
+  UseProwlerPolicies: 
+    Fn::Equals: [Ref: ManagedPolicyArn, "Security-Audit-with-Prowler"]
 
 Outputs:
 


### PR DESCRIPTION
Since Prowler requires two specific policies to function properly, we added a new option in the `AllowedValues` list called `Security-Audit-with-Prowler`. This option automatically attaches the following AWS managed policies to the IAM role:

arn:aws:iam::aws:policy/SecurityAudit
arn:aws:iam::aws:policy/job-function/ViewOnlyAccess

Additionally, we've grouped both `RoleName` and `Principal` under a single label, "OpsGuru Provided Parameter Values," to make the template more user-friendly and organized.